### PR TITLE
The Australian population figure was out of date

### DIFF
--- a/src/country-population.json
+++ b/src/country-population.json
@@ -11,7 +11,7 @@
 {"country" : "Armenia", "population" : "3520000"},
 {"country" : "American Samoa", "population" : "68000"},
 {"country" : "Antigua and Barbuda", "population" : "68000"},
-{"country" : "Australia", "population" : "18886000"},
+{"country" : "Australia", "population" : "23840314"},
 {"country" : "Austria", "population" : "8091800"},
 {"country" : "Azerbaijan", "population" : "7734000"},
 {"country" : "Burundi", "population" : "6695000"},


### PR DESCRIPTION
The figure based on strong statistics taken from the official Government statistics website puts the population at almost 24 million people. I have taken the figure provided from this site: http://www.abs.gov.au/ausstats/abs%40.nsf/94713ad445ff1425ca25682000192af2/1647509ef7e25faaca2568a900154b63?OpenDocument - and used it as the value. This figure is always changing however, but is a fairly closer representation of the Australian population as a whole based on actual numbers and statistical modelling.