### PR TITLE
Fixed UK national animal

### DIFF
--- a/src/country-national-animal.json
+++ b/src/country-national-animal.json
@@ -36,6 +36,6 @@
 {"country" : "Sudan", "animal" : "Secretary Bird"},
 {"country" : "Syria", "animal" : "Eagle "},
 {"country" : "Turkey", "animal" : "Crescent & Star"},
-{"country" : "U.K. ", "animal" : " Barbary Lion"},
+{"country" : "United Kingdom", "animal" : " Barbary Lion"},
 {"country" : "U.S.A.", "animal" : "Golden Rod"}
 ]

--- a/src/country-national-animal.json
+++ b/src/country-national-animal.json
@@ -36,6 +36,6 @@
 {"country" : "Sudan", "animal" : "Secretary Bird"},
 {"country" : "Syria", "animal" : "Eagle "},
 {"country" : "Turkey", "animal" : "Crescent & Star"},
-{"country" : "U.K. ", "animal" : " Rose"},
+{"country" : "U.K. ", "animal" : " Barbary Lion"},
 {"country" : "U.S.A.", "animal" : "Golden Rod"}
 ]


### PR DESCRIPTION
The national animal of the UK is the Barbary Lion not a Rose. Also relabeled 'U.K.' as 'United Kingdom' to be more consistent with other files.