### PR TITLE
Added national animals of UK constituent countries / JSON fix

### DIFF
--- a/src/country-national-animal-or-plant.json
+++ b/src/country-national-animal-or-plant.json
@@ -8,6 +8,7 @@
 {"country" : "Chile", "animal" : "Candor & Huemul"},
 {"country" : "Denmark", "animal" : "Mute Swan "},
 {"country" : "Dominica", "animal" : "Sisserou Parrot"},
+{"country" : "England", "animal" : "Barbary Lion"},
 {"country" : "Eritrea", "animal" : "Arabian Camel"},
 {"country" : "Ethiopia", "animal" : "The Ibex Goat"},
 {"country" : "France", "animal" : "Lily "},
@@ -29,15 +30,14 @@
 {"country" : "Norway", "animal" : "Lion "},
 {"country" : "Pakistan", "animal" : "Crescent"},
 {"country" : "Papua", "animal" : "New Guinea Bird of paradise "},
-{"country" : "Spain", "animal" : "Eagle"},
+{"country" : "Scotland", "animal" : "Unicorn"},
 {"country" : "Senegal", "animal" : "Bhobab Tree"},
 {"country" : "Sierra Leone", "animal" : "Lion"},
+{"country" : "Spain", "animal" : "Eagle"},
 {"country" : "Sri Lanka", "animal" : "Lion "},
 {"country" : "Sudan", "animal" : "Secretary Bird"},
 {"country" : "Syria", "animal" : "Eagle "},
 {"country" : "Turkey", "animal" : "Crescent & Star"},
-{"country" : "England", "animal" : "Barbary Lion"},
-{"country" : "Scotland", "animal" : "Unicorn"},
-{"country" : "Wales", "animal" : "Dragon"},
-{"country" : "U.S.A.", "plant" : "Rose"}
+{"country" : "U.S.A.", "plant" : "Rose"},
+{"country" : "Wales", "animal" : "Dragon"}
 ]

--- a/src/country-national-animal-or-plant.json
+++ b/src/country-national-animal-or-plant.json
@@ -12,7 +12,7 @@
 {"country" : "Ethiopia", "animal" : "The Ibex Goat"},
 {"country" : "France", "animal" : "Lily "},
 {"country" : "Germany", "animal" : "Corn Flower"},
-{"country" : "Guyana", "animal" : "Canje Pheasant",} 
+{"country" : "Guyana", "animal" : "Canje Pheasant"},
 {"country" : "Hong Kong", "animal" : "Bauhinia (Orchid Tree)"},
 {"country" : "India", "animal" : "Lioned Capital "},
 {"country" : "Iran", "animal" : "Rose"},

--- a/src/country-national-animal-or-plant.json
+++ b/src/country-national-animal-or-plant.json
@@ -36,6 +36,8 @@
 {"country" : "Sudan", "animal" : "Secretary Bird"},
 {"country" : "Syria", "animal" : "Eagle "},
 {"country" : "Turkey", "animal" : "Crescent & Star"},
-{"country" : "United Kingdom", "animal" : " Barbary Lion"},
+{"country" : "England", "animal" : "Barbary Lion"},
+{"country" : "Scotland", "animal" : "Unicorn"},
+{"country" : "Wales", "animal" : "Dragon"},
 {"country" : "U.S.A.", "plant" : "Rose"}
 ]


### PR DESCRIPTION
As pointed out by @wjdp the lion is not the national animal of the UK. Instead each constituent country has an animal so I've updated the file accordingly. I've also fixed the alphabetical ordering and a stray comma in the JSON.

http://www.worldatlas.com/webimage/countrys/europe/unitedkingdom/uksymbols.htm