### PR TITLE
Add resources with link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 ## country.json  [![Build Status](https://api.travis-ci.org/samayo/country.json.svg)](https://travis-ci.org/samayo/country.json)
-=======================================
-A simple but useful data of the world (by country) in JSON formats. 
 
-Install
------
+A simple but useful data of the world (by country) in JSON format.
+
+### Download
 Using git
+
 ```bash
 $ git clone https://github.com/samayo/country.json
 ```
 
-Usage
------
+### Usage
 Below, You'll find examples using various languages to integrate/display the data. 
 
 ##### PHP 
-````php
+```php
 <?php 
 
 $file = file_get_contents("/src/country-capital-city.json");
@@ -26,10 +25,10 @@ foreach ($data as $key => $value) {
   // initialize your database .. 
   $db->query("INSERT INTO countries (country, city) VALUES ($country, $city)"); 
 } 
- ````
+```
 
 ##### Node.js
-````javascript
+```javascript
 var fs = require('fs');
 
 fs.readFile('./src/country-capital-city.json', 'utf8', function(err, cities) {
@@ -43,14 +42,13 @@ fs.readFile('./src/country-capital-city.json', 'utf8', function(err, cities) {
   console.log(cities[0]); // { country: 'Afghanistan', city: 'Kabul' }
 
 });
-````
+```
 
-
-#### Contribution.
+### Contributing
 So contributions are welcome. Feel free to PR anything. 
 
-##### Big Changes: 
+#### Big Changes
 If you are fixing a minor typo or something similar, you can do a PR anytime. However, for bigger Changes like country and/or city names, language, population change .. then please include a source, if possible. 
 
-#### LICENSE
+### LICENSE
 MIT

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ fs.readFile('./src/country-capital-city.json', 'utf8', function(err, cities) {
 });
 ```
 
+### Resources
+
+- [Processing country.json data with ramda-cli](https://github.com/raine/ramda-cli/wiki/Cookbook#playing-around-with-countryjson-data)
+
 ### Contributing
 So contributions are welcome. Feel free to PR anything. 
 


### PR DESCRIPTION
So I've been working on a tool that is really good at doing things with JSON so I couldn't resist using it to play around with country.json data.

I added to its wiki some examples what you can do: [Playing around with country.json data](https://github.com/raine/ramda-cli/wiki/Cookbook#playing-around-with-countryjson-data)

One interesting thing in particular is merging the JSON files together into one big array of objects, grouped by country name. When rendered as table, it produces this: 

https://dl.dropboxusercontent.com/u/1103994/countries.html

As you can see, it reveals some errors in the data as well, like country name mismatches, missing data, et cetera.

Feel free to give it a go.